### PR TITLE
Java II, Jurassic: add overtime for upcoming tournament; other assorted XML edits for consistency/maintenance

### DIFF
--- a/competitive/java_ii/map.xml
+++ b/competitive/java_ii/map.xml
@@ -1,100 +1,87 @@
 <map proto="1.4.0">
 <name>Java II</name>
-<version>1.3.1</version>
+<version>1.3.2</version>
 <objective>Capture the enemy's two wools!</objective>
+<time overtime="5m" max-overtime="15m" end-overtime="1m">45m</time>
 <authors>
     <author uuid="b8add1ba-8e13-4673-bc73-4e3ed524d40e"/> <!--  Blazy36  -->
     <author uuid="0c44ca5a-6a42-49b7-81f2-58dc6d2ae3e9"/> <!-- Xerocoles -->
 </authors>
 <teams>
-	<team id="red-team" color="dark red" max="8" max-overfill="8">Red</team>
-	<team id="blue-team" color="blue" max="8" max-overfill="8">Blue</team>
+    <team id="blue-team" color="blue" max="8" max-overfill="8">Blue</team>
+    <team id="red-team" color="dark red" max="8" max-overfill="8">Red</team>
 </teams>
 <kits>
     <kit id="spawn-kit">
-        <item slot="0" unbreakable="true">iron sword</item>
-        <item slot="1" unbreakable="true" enchantment="arrow infinite">bow</item>
-        <item slot="2" unbreakable="true" enchantment="dig speed">iron pickaxe</item>
-        <item slot="3" unbreakable="true" enchantment="dig speed">stone axe</item>
-        <item slot="4" amount="64">wood</item>
-        <item slot="5" amount="48">glass</item>
-        <item slot="7">golden apple</item>
-        <item slot="8" amount="64">golden carrot</item>
-        <item slot="28">arrow</item>
-        <item slot="31" amount="48">wood</item>
-        <potion amplifier="255" duration="5s">resistance</potion>
+        <clear/>
+        <item slot="0" unbreakable="true" material="iron sword"/>
+        <item slot="1" unbreakable="true" material="bow">
+            <enchantment>infinity</enchantment>
+        </item>
+        <item slot="28" material="arrow"/>
+        <item slot="2" unbreakable="true" material="iron pickaxe">
+            <enchantment>efficiency</enchantment>
+        </item>
+        <item slot="3" unbreakable="true" material="stone axe">
+            <enchantment>efficiency</enchantment>
+        </item>
+        <item slot="4" amount="64" material="wood"/>
+        <item slot="31" amount="48" material="wood"/>
+        <item slot="5" amount="48" material="glass"/>
+        <item slot="7" material="golden apple"/>
+        <item slot="8" amount="64" material="golden carrot"/>
         <leggings unbreakable="true" material="chainmail leggings"/>
-    </kit>
-    <kit id="red-kit" parents="spawn-kit">
-        <chestplate color="993333" unbreakable="true" material="leather chestplate"/>
-        <boots color="993333" unbreakable="true" material="leather boots"/>
+        <effect amplifier="255" duration="5s">resistance</effect>
     </kit>
     <kit id="blue-kit" parents="spawn-kit">
         <chestplate color="334CB2" unbreakable="true" material="leather chestplate"/>
         <boots color="334CB2" unbreakable="true" material="leather boots"/>
     </kit>
+    <kit id="red-kit" parents="spawn-kit">
+        <chestplate color="993333" unbreakable="true" material="leather chestplate"/>
+        <boots color="993333" unbreakable="true" material="leather boots"/>
+    </kit>
 </kits>
 <spawns>
-    <spawn team="red-team" kit="red-kit">
-        <regions yaw="90">
-            <cuboid min="241.5,10,172.5" max="239.5,10,170.5"/>
-        </regions>
-    </spawn>
-    <spawn team="blue-team" kit="blue-kit">
-        <regions yaw="-90">
-            <cuboid min="1.5,10,170.5" max="3.5,10,172.5"/>
-        </regions>
-    </spawn>
-    <default>
-        <regions yaw="180">
+    <default yaw="180">
+        <region>
             <cuboid min="122.5,59.1,227.5" max="124.5,59.1,225.5"/>
-        </regions>
+        </region>
     </default>
+    <spawn team="blue-team" kit="blue-kit" yaw="-90">
+        <region>
+            <cuboid min="1.5,10,170.5" max="3.5,10,172.5"/>
+        </region>
+    </spawn>
+    <spawn team="red-team" kit="red-kit" yaw="90">
+        <region>
+            <cuboid min="241.5,10,172.5" max="239.5,10,170.5"/>
+        </region>
+    </spawn>
 </spawns>
 <filters>
     <not id="no-void">
         <void/>
     </not>
-    <team id="only-red">red-team</team>
-    <team id="only-blue">blue-team</team>
-    <all id="only-iron">
-        <material>iron block</material>
-    </all>
-    <not id="deny-red-woolrooms">
-        <any>
-            <filter id="only-red"/>
-            <filter id="no-chest"/>
-        </any>
-    </not>
-    <not id="deny-blue-woolrooms">
-        <any>
-            <filter id="only-blue"/>
-            <filter id="no-chest"/>
-        </any>
-    </not>
+    <material id="only-iron">iron block</material>
     <any id="no-chest">
         <material>chest</material>
     </any>
+    <not id="deny-blue-wool-rooms">
+        <any>
+            <team id="only-blue">blue-team</team>
+            <filter id="no-chest"/>
+        </any>
+    </not>
+    <not id="deny-red-wool-rooms">
+        <any>
+            <team id="only-red">red-team</team>
+            <filter id="no-chest"/>
+        </any>
+    </not>
 </filters>
 <regions>
     <union id="spawns">
-        <union id="red-spawn">
-	        	<rectangle min="245,164" max="239,179"/>
-            <rectangle min="223,160" max="239,183"/>
-            <rectangle min="223,155" max="209,188"/>
-            <rectangle min="204,167" max="209,169"/>
-            <rectangle min="205,164" max="209,169"/>
-            <rectangle min="206,159" max="209,169"/>
-            <rectangle min="207,158" max="209,169"/>
-            <rectangle min="208,156" max="209,169"/>
-            <rectangle min="209,174" max="207,188"/>
-            <rectangle min="205,175" max="207,188"/>
-            <rectangle min="205,175" max="204,185"/>
-            <rectangle min="203,184" max="204,176"/>
-            <rectangle min="202,183" max="204,176"/>
-            <rectangle min="202,179" max="201,180"/>
-            <rectangle min="202,179" max="200,177"/>
-	      </union>
         <union id="blue-spawn">
             <rectangle min="-2,164" max="4,179"/>
             <rectangle min="20,160" max="4,183"/>
@@ -111,17 +98,34 @@
             <rectangle min="41,183" max="39,176"/>
             <rectangle min="41,179" max="42,180"/>
             <rectangle min="41,179" max="43,177"/>
-      	</union>
+        </union>
+        <union id="red-spawn">
+            <rectangle min="245,164" max="239,179"/>
+            <rectangle min="223,160" max="239,183"/>
+            <rectangle min="223,155" max="209,188"/>
+            <rectangle min="204,167" max="209,169"/>
+            <rectangle min="205,164" max="209,169"/>
+            <rectangle min="206,159" max="209,169"/>
+            <rectangle min="207,158" max="209,169"/>
+            <rectangle min="208,156" max="209,169"/>
+            <rectangle min="209,174" max="207,188"/>
+            <rectangle min="205,175" max="207,188"/>
+            <rectangle min="205,175" max="204,185"/>
+            <rectangle min="203,184" max="204,176"/>
+            <rectangle min="202,183" max="204,176"/>
+            <rectangle min="202,179" max="201,180"/>
+            <rectangle min="202,179" max="200,177"/>
+        </union>
     </union>
-    <union id="woolrooms">
-        <union id="red-woolrooms">
+    <union id="wool-rooms">
+        <union id="blue-wool-rooms">
+            <rectangle min="56,106" max="43,118"/> <!-- Pink -->
+            <rectangle min="29,202" max="17,215"/> <!-- Purple -->
+        </union>
+        <union id="red-wool-rooms">
           <rectangle min="214,202" max="226,215"/> <!-- Orange -->
           <rectangle min="187,118" max="200,106"/> <!-- Yellow -->
         </union>
-    	  <union id="blue-woolrooms">
-		        <rectangle min="56,106" max="43,118"/> <!-- Pink -->
-		        <rectangle min="29,202" max="17,215"/> <!-- Purple -->
-	      </union>
     </union>
     <union id="spawner-stuff">
         <cuboid id="spawner" min="122,11,197" max="121,13,198"/>
@@ -129,61 +133,63 @@
         <cuboid id="mid-spawn-activation" min="128,19,192" max="115,9,205"/>
     </union>
     <apply block="only-iron" region="spawns" message="You may not edit the spawn!"/>
-	  <apply enter="only-red" region="red-spawn" message="You may not enter the opponent's spawn!"/>
     <apply enter="only-blue" region="blue-spawn" message="You may not enter the opponent's spawn!"/>
-    <apply block="deny-red-woolrooms" region="red-woolrooms"/>
-    <apply block="deny-blue-woolrooms" region="blue-woolrooms"/>
-    <apply block="only-blue" region="red-woolrooms"/>
-    <apply block="only-red" region="blue-woolrooms"/>
-    <apply use="only-blue" region="red-woolrooms"/>
-    <apply use="only-red" region="blue-woolrooms"/>
-  	<apply enter="only-blue" region="red-woolrooms" message="You may not enter your own wool room!"/>
-    <apply enter="only-red" region="blue-woolrooms" message="You may not enter your own wool room!"/>
+    <apply enter="only-red" region="red-spawn" message="You may not enter the opponent's spawn!"/>
+    <apply enter="only-blue" region="red-wool-rooms" message="You may not enter your own wool room!"/>
+    <apply enter="only-red" region="blue-wool-rooms" message="You may not enter your own wool room!"/>
+    <apply use="only-blue" region="red-wool-rooms"/>
+    <apply use="only-red" region="blue-wool-rooms"/>
+    <apply block="deny-blue-wool-rooms" region="blue-wool-rooms"/>
+    <apply block="deny-red-wool-rooms" region="red-wool-rooms"/>
     <apply block="never" region="spawner" message="You may not destroy the spawner!"/>
-	  <apply block-place="no-void" message="You may not edit the void!"/>
+    <apply block-place="no-void" message="You may not edit the void!"/>
 </regions>
 <renewables>
-    <renewable rate="2" grow="false" particles="true" sound="true" avoid-entities="true" region="spawns">
-        <renew-filter>
-            <material>iron block</material>
-        </renew-filter>
-    </renewable>
+    <renewable rate="2" grow="false" particles="true" sound="true" avoid-entities="true" region="spawns" renew-filter="only-iron"/>
 </renewables>
 <spawners>
     <spawner id="gapple-spawner" spawn-region="mid-spawn-drop" player-region="mid-spawn-activation" max-entities="9999" delay="7s">
-        <item amount="1" material="golden apple"/>
+        <item material="golden apple"/>
     </spawner>
 </spawners>
 <wools>
-	<wool team="red-team" color="pink" location="49.5,12,109.5">
-		<monument><block>240.5,11,167.5</block></monument>
-	</wool>
-	<wool team="red-team" color="purple" location="20.5,12,208.5">
-		<monument><block>240.5,11,175.5</block></monument>
-	</wool>
-	<wool team="blue-team" color="yellow" location="193.5,12,109.5">
-		<monument><block>2.5,11,167.5</block></monument>
-	</wool>
-	<wool team="blue-team" color="orange" location="222.5,12,208.5">
-		<monument><block>2.5,11,175.5</block></monument>
-	</wool>
+    <wool team="blue-team" color="orange" location="222.5,12,208.5">
+        <monument>
+            <block>2.5,11,175.5</block>
+        </monument>
+    </wool>
+    <wool team="blue-team" color="yellow" location="193.5,12,109.5">
+        <monument>
+            <block>2.5,11,167.5</block>
+        </monument>
+    </wool>
+    <wool team="red-team" color="pink" location="49.5,12,109.5">
+        <monument>
+            <block>240.5,11,167.5</block>
+        </monument>
+    </wool>
+    <wool team="red-team" color="purple" location="20.5,12,208.5">
+        <monument>
+            <block>240.5,11,175.5</block>
+        </monument>
+    </wool>
 </wools>
 <toolrepair>
     <tool>iron sword</tool>
     <tool>bow</tool>
     <tool>iron pickaxe</tool>
     <tool>stone axe</tool>
+    <tool>arrow</tool>
 </toolrepair>
 <itemremove>
-    <item>arrow</item>
+    <item>wood</item>
+    <item>glass</item>
     <item>golden carrot</item>
-  	<item>wood</item>
-  	<item>glass</item>
-  	<item>string</item>
-    <item>sapling</item>
     <item>leather chestplate</item>
     <item>chainmail leggings</item>
     <item>leather boots</item>
+    <item>string</item>
+    <item>sapling</item>
     <item>31</item>
     <item>37</item>
     <item>38</item>
@@ -194,17 +200,19 @@
     <item>redstone torch on</item>
     <item>seeds</item>
 </itemremove>
-<killreward>
-	  <item>golden apple</item>
-    <item amount="16">wood</item>
-    <item amount="8">glass</item>
-</killreward>
+<itemkeep>
+    <item>golden apple</item>
+</itemkeep>
+<kill-reward>
+    <item material="golden apple"/>
+    <item amount="16" material="wood"/>
+    <item amount="8" material="glass"/>
+</kill-reward>
 <crafting>
-  	<disable>iron trapdoor</disable>
+    <disable>iron trapdoor</disable>
+    <disable>minecart</disable>
     <disable>boat</disable>
 </crafting>
-<timelock>on</timelock>
 <maxbuildheight>26</maxbuildheight>
-<time results="objective">45m</time>
-<respawn delay="5s" blackout="true"/>
+<respawn delay="5s" auto="true" blackout="true"/>
 </map>

--- a/competitive/java_ii/map.xml
+++ b/competitive/java_ii/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.0">
 <name>Java II</name>
-<version>1.3.2</version>
+<version>1.3.3</version>
 <objective>Capture the enemy's two wools!</objective>
 <time overtime="5m" max-overtime="15m" end-overtime="1m">45m</time>
 <authors>

--- a/competitive/java_ii/map.xml
+++ b/competitive/java_ii/map.xml
@@ -26,8 +26,8 @@
             <enchantment>efficiency</enchantment>
         </item>
         <item slot="4" amount="64" material="wood"/>
-        <item slot="31" amount="48" material="wood"/>
-        <item slot="5" amount="48" material="glass"/>
+        <item slot="31" amount="64" material="wood"/>
+        <item slot="5" amount="64" material="glass"/>
         <item slot="7" material="golden apple"/>
         <item slot="8" amount="64" material="golden carrot"/>
         <leggings unbreakable="true" material="chainmail leggings"/>

--- a/competitive/jurassic/map.xml
+++ b/competitive/jurassic/map.xml
@@ -201,6 +201,7 @@
 <kill-reward>
     <item material="golden apple"/>
     <item amount="16" damage="4" material="wood"/>
+    <item amount="8" material="glass"/>
 </kill-reward>
 <crafting>
     <disable>iron trapdoor</disable>

--- a/competitive/jurassic/map.xml
+++ b/competitive/jurassic/map.xml
@@ -59,7 +59,7 @@
         </region>
     </spawn>
     <spawn team="yellow-team" kit="yellow-kit" yaw="180">
-        <region yaw="180">
+        <region>
             <point>-121.5,6,174.5</point>
         </region>
     </spawn>

--- a/competitive/jurassic/map.xml
+++ b/competitive/jurassic/map.xml
@@ -1,7 +1,8 @@
 <map proto="1.4.0">
 <name>Jurassic</name>
-<version>2.7.0</version>
+<version>2.7.1</version>
 <objective>Capture the enemy's two wools!</objective>
+<time overtime="5m" max-overtime="15m" end-overtime="1m">45m</time>
 <authors>
     <author uuid="0c44ca5a-6a42-49b7-81f2-58dc6d2ae3e9"/> <!-- Xerocoles -->
 </authors>
@@ -9,84 +10,87 @@
     <contributor uuid="fe3608b7-d105-4029-8800-34b3147065b6" contribution="Most of obs-spawn Dino"/> <!-- rockymine -->
 </contributors>
 <teams>
-	<team id="yellow-team" color="yellow" max="8" max-overfill="8">Yellow</team>
-	<team id="purple-team" color="dark purple" max="8" max-overfill="8">Purple</team>
+    <team id="purple-team" color="dark purple" max="8" max-overfill="8">Purple</team>
+    <team id="yellow-team" color="yellow" max="8" max-overfill="8">Yellow</team>
 </teams>
 <kits>
     <kit id="spawn-kit">
-        <item slot="0" unbreakable="true">iron sword</item>
-        <item slot="1" unbreakable="true" enchantment="arrow infinite">bow</item>
-        <item slot="2" unbreakable="true" enchantment="dig speed">iron pickaxe</item>
-        <item slot="3" unbreakable="true" enchantment="dig speed">stone axe</item>
-        <item slot="4" amount="64" damage="4">wood</item>
-        <item slot="5" amount="64">glass</item>
-        <item slot="7">golden apple</item>
-        <item slot="8" amount="64">golden carrot</item>
-        <item slot="28">arrow</item>
-        <item slot="29" unbreakable="true" enchantment="dig speed">iron spade</item>
-        <item slot="31" amount="64" damage="4">wood</item>
-        <potion amplifier="255" duration="6s">resistance</potion>
+        <clear/>
+        <item slot="0" unbreakable="true" material="iron sword"/>
+        <item slot="1" unbreakable="true" material="bow">
+            <enchantment>infinity</enchantment>
+        </item>
+        <item slot="28" material="arrow"/>
+        <item slot="2" unbreakable="true" material="iron pickaxe">
+            <enchantment>efficiency</enchantment>
+        </item>
+        <item slot="3" unbreakable="true" material="stone axe">
+            <enchantment>efficiency</enchantment>
+        </item>
+        <item slot="30" unbreakable="true" material="iron spade">
+            <enchantment>efficiency</enchantment>
+        </item>
+        <item slot="4" amount="64" damage="4" material="wood"/>
+        <item slot="31" amount="64" damage="4" material="wood"/>
+        <item slot="5" amount="64" material="glass"/>
+        <item slot="7" material="golden apple"/>
+        <item slot="8" amount="64" material="golden carrot"/>
         <leggings unbreakable="true" material="chainmail leggings"/>
-    </kit>
-    <kit id="yellow-kit" parents="spawn-kit">
-        <chestplate color="E5E533" unbreakable="true" material="leather chestplate"/>
-        <boots color="E5E533" unbreakable="true" material="leather boots"/>
+        <effect amplifier="255" duration="6s">resistance</effect>
     </kit>
     <kit id="purple-kit" parents="spawn-kit">
         <chestplate color="7F3FB2" unbreakable="true" material="leather chestplate"/>
         <boots color="7F3FB2" unbreakable="true" material="leather boots"/>
     </kit>
+    <kit id="yellow-kit" parents="spawn-kit">
+        <chestplate color="E5E533" unbreakable="true" material="leather chestplate"/>
+        <boots color="E5E533" unbreakable="true" material="leather boots"/>
+    </kit>
 </kits>
 <spawns>
-    <spawn team="yellow-team" kit="yellow-kit">
-        <regions yaw="180">
-            <point>-121.5,6,174.5</point>
-        </regions>
-    </spawn>
-    <spawn team="purple-team" kit="purple-kit">
-        <regions yaw="0">
-            <point>-121.5,6,-51.5</point>
-        </regions>
-    </spawn>
-    <default>
-        <regions yaw="-90">
+    <default yaw="-90">
+        <region>
             <cuboid min="-221.5,49,65.5" max="-216.5,49,60.5"/>
-        </regions>
+        </region>
     </default>
+    <spawn team="purple-team" kit="purple-kit" yaw="0">
+        <region>
+            <point>-121.5,6,-51.5</point>
+        </region>
+    </spawn>
+    <spawn team="yellow-team" kit="yellow-kit" yaw="180">
+        <region yaw="180">
+            <point>-121.5,6,174.5</point>
+        </region>
+    </spawn>
 </spawns>
 <filters>
     <not id="no-void">
-      <void/>
+        <void/>
     </not>
-    <team id="only-yellow">yellow-team</team>
-    <team id="only-purple">purple-team</team>
-    <all id="only-iron">
-        <material>iron block</material>
-    </all>
-    <not id="deny-yellow-woolrooms">
-        <any>
-            <filter id="only-yellow"/>
-            <filter id="no-chest"/>
-        </any>
-    </not>
-    <not id="deny-purple-woolrooms">
-        <any>
-            <filter id="only-purple"/>
-            <filter id="no-chest"/>
-        </any>
-    </not>
+    <material id="only-iron">iron block</material>
     <any id="no-chest">
         <material>chest</material>
     </any>
+    <not id="deny-purple-wool-rooms">
+        <any>
+            <team id="only-purple">purple-team</team>
+            <filter id="no-chest"/>
+        </any>
+    </not>
+    <not id="deny-yellow-wool-rooms">
+        <any>
+            <team id="only-yellow">yellow-team</team>
+            <filter id="no-chest"/>
+        </any>
+    </not>
 </filters>
 <regions>
     <union id="bridges">
         <cuboid min="-126,11,125" max="-117,19,121"/>
         <cuboid min="-126,11,-2" max="-117,19,2"/>
     </union>
-    <union id="buildable">
-        <rectangle min="-175,138" max="-68,-15"/>
-    </union>
+    <rectangle id="buildable" min="-175,138" max="-68,-15"/>
     <union id="not-buildable">
         <rectangle min="-117,138" max="-126,98"/>
         <rectangle min="-127,98" max="-116,115"/>
@@ -104,63 +108,65 @@
     </union>
     <union id="spawns">
         <union id="yellow-spawn">
-	        	<rectangle min="-104,148" max="-139,192"/>
-	      </union>
+            <rectangle min="-104,148" max="-139,192"/>
+        </union>
         <union id="purple-spawn">
-	        	<rectangle min="-139,-25" max="-104,-69"/>
-      	</union>
+            <rectangle min="-139,-25" max="-104,-69"/>
+        </union>
     </union>
-    <union id="woolrooms">
-    	  <union id="yellow-woolrooms">
-		        <rectangle min="-65,165" max="-78,181"/> <!-- Dark Grey -->
-		        <rectangle min="-165,165" max="-178,181"/> <!-- Red -->
-	      </union>
-	      <union id="purple-woolrooms">
-	        	<rectangle min="-178,-42" max="-165,-58"/> <!-- Lime -->
-		        <rectangle min="-78,-42" max="-65,-58"/> <!-- Blue -->
-	      </union>
+    <union id="wool-rooms">
+        <union id="purple-wool-rooms">
+            <rectangle min="-78,-42" max="-65,-58"/> <!-- Blue -->
+            <rectangle min="-178,-42" max="-165,-58"/> <!-- Lime -->
+        </union>
+        <union id="yellow-wool-rooms">
+            <rectangle min="-65,165" max="-78,181"/> <!-- Dark Grey -->
+            <rectangle min="-165,165" max="-178,181"/> <!-- Red -->
+        </union>
     </union>
     <union id="spawners">
         <cuboid min="-65,7,62" max="-66,9,61"/>
         <cuboid min="-177,7,62" max="-178,9,61"/>
     </union>
-    <apply block="only-iron" region="spawns" message="You may not edit the spawn!"/>
-	  <apply enter="only-yellow" region="yellow-spawn" message="You may not enter the opponent's spawn!"/>
     <apply enter="only-purple" region="purple-spawn" message="You may not enter the opponent's spawn!"/>
-    <apply block="deny-yellow-woolrooms" region="yellow-woolrooms"/>
-    <apply block="deny-purple-woolrooms" region="purple-woolrooms"/>
-    <apply block="only-purple" region="yellow-woolrooms"/>
-    <apply block="only-yellow" region="purple-woolrooms"/>
-    <apply use="only-purple" region="yellow-woolrooms"/>
-    <apply use="only-yellow" region="purple-woolrooms"/>
-  	<apply enter="only-purple" region="yellow-woolrooms" message="You may not enter your own wool room!"/>
-    <apply enter="only-yellow" region="purple-woolrooms" message="You may not enter your own wool room!"/>
+    <apply enter="only-yellow" region="yellow-spawn" message="You may not enter the opponent's spawn!"/>
+    <apply enter="only-purple" region="yellow-wool-rooms" message="You may not enter your own wool room!"/>
+    <apply enter="only-yellow" region="purple-wool-rooms" message="You may not enter your own wool room!"/>
+    <apply use="only-purple" region="yellow-wool-rooms"/>
+    <apply use="only-yellow" region="purple-wool-rooms"/>
+    <apply block="only-iron" region="spawns" message="You may not edit the spawn!"/>
+    <apply block="deny-purple-wool-rooms" region="purple-wool-rooms"/>
+    <apply block="deny-yellow-wool-rooms" region="yellow-wool-rooms"/>
     <apply block="never" region="spawners" message="You may not destroy the spawners!"/>
     <apply block="never" region="bridges" message="You may not edit the bridge!"/>
     <apply block-place="never" region="not-buildable" message="You may not edit the void!"/>
     <apply block="always" region="buildable"/>
-	  <apply block-place="no-void" message="You may not edit the void!"/>
+    <apply block-place="no-void" message="You may not edit the void!"/>
 </regions>
 <renewables>
-    <renewable rate="1" grow="false" particles="true" sound="true" avoid-entities="true" region="spawns">
-        <renew-filter>
-            <material>iron block</material>
-        </renew-filter>
-    </renewable>
+    <renewable rate="1" grow="false" particles="true" sound="true" avoid-entities="true" region="spawns" renew-filter="only-iron"/>
 </renewables>
 <wools>
-	<wool team="yellow-team" color="lime" location="-175,14,-54">
-		<monument><block>-123.5,7,151.5</block></monument>
-	</wool>
-	<wool team="yellow-team" color="blue" location="-68,14,-54">
-		<monument><block>-119.5,7,151.5</block></monument>
-	</wool>
-	<wool team="purple-team" color="red" location="-175,14,177">
-		<monument><block>-123.5,7,-28.5</block></monument>
-	</wool>
-	<wool team="purple-team" color="magenta" location="-68,14,177">
-		<monument><block>-119.5,7,-28.5</block></monument>
-	</wool>
+    <wool team="purple-team" color="magenta" location="-68,14,177">
+        <monument>
+            <block>-119.5,7,-28.5</block>
+        </monument>
+    </wool>
+    <wool team="purple-team" color="red" location="-175,14,177">
+        <monument>
+            <block>-123.5,7,-28.5</block>
+        </monument>
+    </wool>
+    <wool team="yellow-team" color="blue" location="-68,14,-54">
+        <monument>
+            <block>-119.5,7,151.5</block>
+        </monument>
+    </wool>
+    <wool team="yellow-team" color="lime" location="-175,14,-54">
+        <monument>
+            <block>-123.5,7,151.5</block>
+        </monument>
+    </wool>
 </wools>
 <toolrepair>
     <tool>iron sword</tool>
@@ -168,17 +174,17 @@
     <tool>iron pickaxe</tool>
     <tool>stone axe</tool>
     <tool>iron spade</tool>
+    <tool>arrow</tool>
 </toolrepair>
 <itemremove>
-    <item>arrow</item>
+    <item damage="4">wood</item>
     <item>golden carrot</item>
-  	<item damage="4">wood</item>
-  	<item>glass</item>
-  	<item>string</item>
-    <item>sapling</item>
+    <item>glass</item>
     <item>leather chestplate</item>
     <item>chainmail leggings</item>
     <item>leather boots</item>
+    <item>string</item>
+    <item>sapling</item>
     <item>31</item>
     <item>37</item>
     <item>38</item>
@@ -189,17 +195,18 @@
     <item>redstone torch on</item>
     <item>seeds</item>
 </itemremove>
-<killreward>
-	  <item>golden apple</item>
-    <item amount="16" damage="4">wood</item>
-</killreward>
+<itemkeep>
+    <item>golden apple</item>
+</itemkeep>
+<kill-reward>
+    <item material="golden apple"/>
+    <item amount="16" damage="4" material="wood"/>
+</kill-reward>
 <crafting>
-	<disable>iron trapdoor</disable>
-	<disable>minecart</disable>
-	<disable>boat</disable>
+    <disable>iron trapdoor</disable>
+    <disable>minecart</disable>
+    <disable>boat</disable>
 </crafting>
-<timelock>on</timelock>
 <maxbuildheight>25</maxbuildheight>
-<time results="objective">45m</time>
-<respawn delay="6s" blackout="true"/>
+<respawn delay="6s" auto="true" blackout="true"/>
 </map>


### PR DESCRIPTION
**Both maps**

- Added overtime to time limit module
- Alphabetization of various modules relating to teams, wools, etc.
- Specify all items within kits in the same manner (using `material="..."`)
- Condensed filters where possible
- Separated filter applications by `enter`, `use`, and `block`
- Removed unnecessary/duplicate filter applications
- Move arrows to `<toolrepair>`, to prevent players losing theirs if somehow dropped while avoiding duplicates
- Moved all items relevant to spawn kits to top of `<itemremove>`
- Golden apples in `<itemkeep>`, with `<clear/>` in spawn kit
- Simplified some other modules
- Set players to autorespawn
- Various XML format stuff for better visibility, most prominently ensuring use of four spaces instead of tab

**Specific to Java II**
- Disable crafting of minecarts as is done in Jurassic